### PR TITLE
Fix feed API error

### DIFF
--- a/controllers/articles.js
+++ b/controllers/articles.js
@@ -256,9 +256,9 @@ module.exports.getAllArticles = async (req, res) => {
 module.exports.getFeed = async (req, res) => {
 	try {
 		const query = `
-            SELECT UserEmail
-            FROM followers
-            WHERE followerEmail = "${req.user.email}"`;
+            SELECT "UserEmail"
+            FROM "Followers"
+            WHERE "followerEmail" = '${req.user.email}'`;
 		const followingUsers = await sequelize.query(query);
 		if (followingUsers[0].length == 0) {
 			return res.json({ articles: [] });


### PR DESCRIPTION
The sql query string for feed api throw error 'relation "followers" does not exist', because the 'followers' should be 'Followers'. This PR also add double quotes to words containing uppercase letter since postgresql will lowercase them if they are not surrounded by double quotes.